### PR TITLE
Register routes on router instance before initialization

### DIFF
--- a/app.js
+++ b/app.js
@@ -283,22 +283,22 @@ vani.defineComponent('RegisterForm', ({ vani }) => {
 // ==================== ROUTE DEFINITIONS ====================
 
 // Public routes
-vani.defineRoute('/login', 'LoginForm', {}, [
+vaniRouter.defineRoute('/login', 'LoginForm', {}, [
     vaniMiddlewares.auth.requireGuest,
     vaniMiddlewares.router.scrollToTop
 ]);
 
-vani.defineRoute('/register', 'RegisterForm', {}, [
+vaniRouter.defineRoute('/register', 'RegisterForm', {}, [
     vaniMiddlewares.auth.requireGuest
 ]);
 
 // Protected routes
-vani.defineRoute('/', 'Dashboard', {}, [
+vaniRouter.defineRoute('/', 'Dashboard', {}, [
     vaniMiddlewares.auth.requireAuth,
     vaniMiddlewares.router.navigationLogger
 ]);
 
-vani.defineRoute('/dashboard', 'Dashboard', {}, [
+vaniRouter.defineRoute('/dashboard', 'Dashboard', {}, [
     vaniMiddlewares.auth.requireAuth,
     vaniMiddlewares.router.navigationLogger
 ]);


### PR DESCRIPTION
## Summary
- Register login, register, and dashboard routes on `vaniRouter` instead of global `vani`
- Keep router initialization after route definitions

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aacea15d308326ae6b1431a775e0fe