### PR TITLE
Implement mock authentication with login redirect and dashboard

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -120,18 +120,8 @@ const authMiddlewares = {
     // Require authentication
     requireAuth: (context, next) => {
         if (!context.vani.isAuthenticated()) {
-            const error = MiddlewareUtils.createError(
-                'AUTH_REQUIRED',
-                'Authentication required',
-                { path: context.path }
-            );
-            
-            if (context.vani.pluginSystem) {
-                context.vani.pluginSystem.executeHook('middleware:auth:required', error);
-            }
-            
             context.redirect('/login?return=' + encodeURIComponent(context.path));
-            throw error;
+            throw new Error('Navigation cancelled');
         }
         return next();
     },
@@ -139,18 +129,8 @@ const authMiddlewares = {
     // Require guest (non-authenticated)
     requireGuest: (context, next) => {
         if (context.vani.isAuthenticated()) {
-            const error = MiddlewareUtils.createError(
-                'ALREADY_AUTHENTICATED',
-                'Already authenticated',
-                { user: context.vani.auth.user }
-            );
-            
-            if (context.vani.pluginSystem) {
-                context.vani.pluginSystem.executeHook('middleware:auth:guest-violation', error);
-            }
-            
             context.redirect('/');
-            throw error;
+            throw new Error('Navigation cancelled');
         }
         return next();
     },

--- a/mock-api.js
+++ b/mock-api.js
@@ -1,0 +1,47 @@
+// mock-api.js - simple mock API for authentication
+export function setupMockApi() {
+  const users = [
+    { email: 'user@example.com', password: 'password123', role: 'user' }
+  ];
+
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = async (input, init = {}) => {
+    if (typeof input === 'string' && input.startsWith('/api')) {
+      if (input === '/api/login' && (init.method || 'GET').toUpperCase() === 'POST') {
+        try {
+          const { email, password } = JSON.parse(init.body || '{}');
+          const user = users.find(u => u.email === email && u.password === password);
+          if (user) {
+            return new Response(
+              JSON.stringify({
+                user: { email: user.email, role: user.role },
+                tokens: {
+                  access: 'mock-jwt-token',
+                  refresh: 'mock-refresh-token'
+                }
+              }),
+              { status: 200, headers: { 'Content-Type': 'application/json' } }
+            );
+          }
+          return new Response(
+            JSON.stringify({ message: 'Invalid credentials' }),
+            { status: 401, headers: { 'Content-Type': 'application/json' } }
+          );
+        } catch (err) {
+          return new Response(
+            JSON.stringify({ message: 'Bad Request' }),
+            { status: 400, headers: { 'Content-Type': 'application/json' } }
+          );
+        }
+      }
+
+      return new Response(
+        JSON.stringify({ message: 'Not Found' }),
+        { status: 404, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    return originalFetch(input, init);
+  };
+}


### PR DESCRIPTION
## Summary
- add mock API to simulate authentication and return JWT tokens
- enhance login form to use mock API and redirect back to dashboard
- improve dashboard with welcome message and sign-out option
- fix auth middleware to redirect without showing error page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aad0f63c68832692cd3ac7a1e87ae6