### PR TITLE
fix: disable analytics when GA ID missing

### DIFF
--- a/middleware.js
+++ b/middleware.js
@@ -343,8 +343,10 @@ const routerMiddlewares = {
                 fbq('track', eventName, event);
             }
 
-            // Custom analytics endpoint
-            if (typeof navigator.sendBeacon === 'function') {
+            // Custom analytics endpoint - only send when analytics IDs are configured
+            const GA_ID = import.meta.env.VITE_GA_ID;
+            const FB_PIXEL_ID = import.meta.env.VITE_FB_PIXEL_ID;
+            if ((GA_ID || FB_PIXEL_ID) && typeof navigator.sendBeacon === 'function') {
                 navigator.sendBeacon('/api/analytics', JSON.stringify(event));
             }
 

--- a/plugins.js
+++ b/plugins.js
@@ -898,8 +898,24 @@ const analyticsPlugin = {
         const cfg = (window.vaniApp && window.vaniApp.config) || {};
         this.gaId = options.gaId ?? cfg.integrations?.gaId ?? import.meta.env.VITE_GA_ID;
         this.fbPixelId = options.fbPixelId ?? cfg.integrations?.fbPixelId ?? import.meta.env.VITE_FB_PIXEL_ID;
-        const baseURL = options.baseURL ?? cfg.api?.baseURL ?? import.meta.env.VITE_API_URL ?? '/api';
-        this.endpoint = options.endpoint ?? (String(baseURL).replace(/\/$/, '') + '/analytics');
+        const baseURL = options.baseURL ?? cfg.api?.baseURL ?? import.meta.env.VITE_API_URL;
+        const defaultEndpoint = (this.gaId || this.fbPixelId) && baseURL
+            ? (String(baseURL).replace(/\/$/, '') + '/analytics')
+            : undefined;
+        this.endpoint = options.endpoint ?? defaultEndpoint;
+
+        // Disable analytics entirely if no tracking configuration is provided
+        if (!this.gaId && !this.fbPixelId && !this.endpoint) {
+            console.warn('⚠️ Analytics plugin disabled: no tracking IDs configured');
+            this.options = {
+                trackPageViews: false,
+                trackEvents: false,
+                trackErrors: false,
+                trackPerformance: false,
+                ...options
+            };
+            return;
+        }
 
         this.options = {
             trackPageViews: true,
@@ -912,7 +928,7 @@ const analyticsPlugin = {
         this.setupAnalytics();
         this.setupAutoTracking();
         this.loadAnalyticsLibraries();
-        
+
         console.log('✅ Analytics plugin initialized');
     },
 


### PR DESCRIPTION
## Summary
- avoid default analytics endpoint when no tracking IDs present
- skip middleware analytics beacon if GA tracking is disabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aad7d5e4dc832695e75ca16e26a627